### PR TITLE
More updates for v4

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hazelcast.Net" Version="4.0.1" />
+    <PackageReference Include="Hazelcast.Net" Version="4.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -26,21 +26,30 @@ namespace Client
             var options = new HazelcastOptionsBuilder()
                 .With(args)
                 .WithConsoleLogger()
-                //.With("Logging:LogLevel:Hazelcast", "Information")
+                .With("Logging:LogLevel:Hazelcast", "Information")
                 .Build();
 
             // log level must be a valid Microsoft.Extensions.Logging.LogLevel value
             //   Trace | Debug | Information | Warning | Error | Critical | None
 
-            // set the cluster name
-            options.ClusterName = "YOUR_CLUSTER_NAME";
+            if (args.Length == 0)
+            {
+                // it is OK to pass the arguments in the command line
+                // otherwise, they must be specified here
+                
+                // set the cluster name
+                options.ClusterName = "YOUR_CLUSTER_NAME";
 
-            // set the cloud discovery token and url
-            options.Networking.Cloud.DiscoveryToken = "YOUR_CLUSTER_DISCOVERY_TOKEN";
-            options.Networking.Cloud.Url = "YOUR_DISCOVERY_URL";
+                // set the cloud discovery token and url
+                options.Networking.Cloud.DiscoveryToken = "YOUR_CLUSTER_DISCOVERY_TOKEN";
+                options.Networking.Cloud.Url = new Uri("YOUR_DISCOVERY_URL");
+            }
 
             // make sure the client stays connected
             options.Networking.ReconnectMode = ReconnectMode.ReconnectAsync;
+
+            // enable metrics
+            options.Metrics.Enabled = true;
 
             Console.WriteLine(" ok.");
 

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Hazelcast;
+using Hazelcast.Networking;
 using Microsoft.Extensions.Logging;
 
 namespace Client
@@ -36,7 +37,10 @@ namespace Client
 
             // set the cloud discovery token and url
             options.Networking.Cloud.DiscoveryToken = "YOUR_CLUSTER_DISCOVERY_TOKEN";
-            //options.Networking.Cloud.Url = "YOUR_DISCOVERY_URL";
+            options.Networking.Cloud.Url = "YOUR_DISCOVERY_URL";
+
+            // make sure the client stays connected
+            options.Networking.ReconnectMode = ReconnectMode.ReconnectAsync;
 
             Console.WriteLine(" ok.");
 

--- a/ClientWithSsl/ClientWithSsl.csproj
+++ b/ClientWithSsl/ClientWithSsl.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hazelcast.Net" Version="4.0.1" />
+    <PackageReference Include="Hazelcast.Net" Version="4.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 

--- a/ClientWithSsl/Program.cs
+++ b/ClientWithSsl/Program.cs
@@ -2,6 +2,7 @@
 using System.Security.Authentication;
 using System.Threading.Tasks;
 using Hazelcast;
+using Hazelcast.Networking;
 using Microsoft.Extensions.Logging;
 
 namespace ClientWithSsl
@@ -37,7 +38,10 @@ namespace ClientWithSsl
 
             // set the cloud discovery token and url
             options.Networking.Cloud.DiscoveryToken = "YOUR_CLUSTER_DISCOVERY_TOKEN";
-            //options.Networking.Cloud.Url = "YOUR_DISCOVERY_URL";
+            options.Networking.Cloud.Url = "YOUR_DISCOVERY_URL";
+
+            // make sure the client stays connected
+            options.Networking.ReconnectMode = ReconnectMode.ReconnectAsync;
 
             // set ssl
             options.Networking.Ssl.Enabled = true;

--- a/ClientWithSsl/Program.cs
+++ b/ClientWithSsl/Program.cs
@@ -27,21 +27,30 @@ namespace ClientWithSsl
             var options = new HazelcastOptionsBuilder()
                 .With(args)
                 .WithConsoleLogger()
-                //.With("Logging:LogLevel:Hazelcast", "Information")
+                .With("Logging:LogLevel:Hazelcast", "Information")
                 .Build();
 
             // log level must be a valid Microsoft.Extensions.Logging.LogLevel value
             //   Trace | Debug | Information | Warning | Error | Critical | None
 
-            // set the cluster name
-            options.ClusterName = "YOUR_CLUSTER_NAME";
+            if (args.Length == 0)
+            {
+                // it is OK to pass the arguments in the command line
+                // otherwise, they must be specified here
 
-            // set the cloud discovery token and url
-            options.Networking.Cloud.DiscoveryToken = "YOUR_CLUSTER_DISCOVERY_TOKEN";
-            options.Networking.Cloud.Url = "YOUR_DISCOVERY_URL";
+                // set the cluster name
+                options.ClusterName = "YOUR_CLUSTER_NAME";
+
+                // set the cloud discovery token and url
+                options.Networking.Cloud.DiscoveryToken = "YOUR_CLUSTER_DISCOVERY_TOKEN";
+                options.Networking.Cloud.Url = new Uri("YOUR_DISCOVERY_URL");
+            }
 
             // make sure the client stays connected
             options.Networking.ReconnectMode = ReconnectMode.ReconnectAsync;
+            
+            // enable metrics
+            options.Metrics.Enabled = true;
 
             // set ssl
             options.Networking.Ssl.Enabled = true;


### PR DESCRIPTION
More updates for v4, enable metrics by default, cleaner code.

Note: this depends on Hazelcast.Net 4.0.2 which is not released yet - update the package dependency to the latest 4.0.2 preview.