### PR TITLE
Bugfix/5.0

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hazelcast.Net" Version="5.0.*" />
+    <PackageReference Include="Hazelcast.Net" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hazelcast.Net" Version="5.0.0" />
+    <PackageReference Include="Hazelcast.Net" Version="5.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hazelcast.Net" Version="4.0.2" />
+    <PackageReference Include="Hazelcast.Net" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 

--- a/ClientWithSsl/ClientWithSsl.csproj
+++ b/ClientWithSsl/ClientWithSsl.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hazelcast.Net" Version="5.0.*" />
+    <PackageReference Include="Hazelcast.Net" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 

--- a/ClientWithSsl/ClientWithSsl.csproj
+++ b/ClientWithSsl/ClientWithSsl.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hazelcast.Net" Version="5.0.0" />
+    <PackageReference Include="Hazelcast.Net" Version="5.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 

--- a/ClientWithSsl/ClientWithSsl.csproj
+++ b/ClientWithSsl/ClientWithSsl.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hazelcast.Net" Version="4.0.2" />
+    <PackageReference Include="Hazelcast.Net" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Bugfix the samples for 5.0:
* Align the target framework, both for non-SSL and SSL, to `net5.0` which is the latest .NET version that we support
* Fix the package reference to depend on `Hazelcast.Net` package version `5.0.1`

Note: we've had discussions about changing the package version to `5.0.*` which would pick the latest 5.0 patch release, or even `5.0.*-*` which would pick the latest 5.0 patch (pre-) release, but the Cloud team prefers to stick to static versions and test each new version when released. So, using `5.0.1` here.