### PR TITLE
HZC-2939: Net6.0 Support Added

### DIFF
--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ClientWithSsl/ClientWithSsl.csproj
+++ b/ClientWithSsl/ClientWithSsl.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Recent dotnet client fails with net5.0 version. Upgrading project version to net6.0 resolves the issue. This version is the one suggested on hazelcast csharp client repo.
![Screen Shot 2022-06-02 at 15 48 06](https://user-images.githubusercontent.com/1237982/171632944-f893e663-82ae-4e8f-b96a-f3a999229d72.png)
